### PR TITLE
feat: add configurable job log retention

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,11 @@ SECRET_CLIENT_COOKIE_VAR=
 DATABASE_URL="postgresql://postgres:password@localhost:5432/zapcron"
 ENABLE_QUERY_LOGGING=false
 
+# Job log retention (0 = disabled, logs kept until manually cleared)
+LOG_RETENTION_DAYS=0
+# Secret for POST /api/logs/purge (optional; required to run automated retention)
+LOG_RETENTION_CRON_SECRET=
+
 # Redis
 REDIS_HOST=
 REDIS_PORT=

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Ensure the following are installed on your system before running ZapCron:
 
 ZapCron uses environment variables for configuration. Refer to the provided `.env.example` file for required and optional variables. Customize it according to your needs.
 
+### Job log retention
+
+Set `LOG_RETENTION_DAYS` to automatically delete job execution logs older than that many days (`0` disables retention). Schedule a periodic call to `POST /api/logs/purge` with `LOG_RETENTION_CRON_SECRET` in the `Authorization: Bearer` header or `x-log-retention-secret` header (for example via Kubernetes CronJob or system cron). Admins can also purge expired logs from **Settings → Log Management**.
+
 ## Usage
 
 Once ZapCron is running, you can define your webhook schedules and manage them through the API. Refer to the API documentation (coming soon) for detailed instructions.

--- a/src/app/api/logs/purge/route.ts
+++ b/src/app/api/logs/purge/route.ts
@@ -1,0 +1,37 @@
+import { env } from "@zapcron/env";
+import { db } from "@zapcron/server/db";
+import {
+  getLogRetentionCutoffDate,
+  purgeExpiredLogs,
+} from "@zapcron/server/logs/retention";
+
+export const POST = async (request: Request) => {
+  if (!env.LOG_RETENTION_CRON_SECRET) {
+    return Response.json(
+      { error: "Log retention cron is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const authHeader = request.headers.get("authorization");
+  const bearerToken = authHeader?.startsWith("Bearer ")
+    ? authHeader.slice("Bearer ".length)
+    : null;
+  const cronSecret = request.headers.get("x-log-retention-secret");
+
+  if (
+    bearerToken !== env.LOG_RETENTION_CRON_SECRET &&
+    cronSecret !== env.LOG_RETENTION_CRON_SECRET
+  ) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const result = await purgeExpiredLogs(db);
+  const cutoffDate = getLogRetentionCutoffDate();
+
+  return Response.json({
+    success: true,
+    ...result,
+    cutoffDate: cutoffDate?.toISOString() ?? null,
+  });
+};

--- a/src/components/features/settings/settings-logs.tsx
+++ b/src/components/features/settings/settings-logs.tsx
@@ -17,7 +17,7 @@ import {
 } from "@internationalized/date";
 import { ActionPopover } from "@zapcron/components/common";
 import { api } from "@zapcron/trpc/react";
-import { HardDrive, Rows2 } from "lucide-react";
+import { CalendarClock, HardDrive, Rows2, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 
@@ -49,6 +49,16 @@ const SettingsLogs = () => {
     onSuccess() {
       void utils.log.invalidate();
       toast.success("Successfully cleared logs");
+    },
+  });
+
+  const purgeExpiredLogs = api.log.purgeExpired.useMutation({
+    onSuccess(result) {
+      void utils.log.invalidate();
+      toast.success(`Purged ${result.deleted} expired log(s)`);
+    },
+    onError() {
+      toast.error("Failed to purge expired logs");
     },
   });
   return (
@@ -83,6 +93,64 @@ const SettingsLogs = () => {
               </p>
             </div>
           </div>
+          <h3 className="mb-2 font-medium text-md">Retention</h3>
+          <div className="mb-6 flex flex-wrap gap-8">
+            <div className="flex items-center gap-2">
+              <Chip
+                startContent={<CalendarClock size={12} />}
+                size="sm"
+                color={stats.retentionEnabled ? "success" : "default"}
+              >
+                Policy
+              </Chip>
+              <p className="text-gray-700 text-sm dark:text-gray-200">
+                {stats.retentionEnabled
+                  ? `Keep logs for ${stats.retentionDays} day(s)`
+                  : "Disabled (set LOG_RETENTION_DAYS)"}
+              </p>
+            </div>
+            {stats.retentionEnabled && (
+              <>
+                <div className="flex items-center gap-2">
+                  <Chip size="sm" variant="flat">
+                    Cutoff
+                  </Chip>
+                  <p className="text-gray-700 text-sm dark:text-gray-200">
+                    {stats.cutoffDate
+                      ? new Date(stats.cutoffDate).toLocaleString()
+                      : "—"}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Chip size="sm" color="warning" variant="flat">
+                    Expired
+                  </Chip>
+                  <p className="text-gray-700 text-sm dark:text-gray-200">
+                    {stats.expiredCount}
+                  </p>
+                </div>
+              </>
+            )}
+          </div>
+          {stats.retentionEnabled && stats.expiredCount > 0 && (
+            <div className="mb-6">
+              <ActionPopover
+                placement="right"
+                trigger={
+                  <Button
+                    isLoading={purgeExpiredLogs.isPending}
+                    color="warning"
+                    size="sm"
+                    className="w-fit"
+                    startContent={<Trash2 size={14} />}
+                  >
+                    Purge Expired Logs
+                  </Button>
+                }
+                onAction={() => purgeExpiredLogs.mutate()}
+              />
+            </div>
+          )}
           <h3 className="mb-2 font-medium text-md">Clear</h3>
           <div className="mb-2 flex items-center gap-2">
             <Switch

--- a/src/env.js
+++ b/src/env.js
@@ -23,6 +23,13 @@ export const env = createEnv({
     DATABASE_URL: z.string().url(),
     DEBUG: z.boolean().optional().default(false),
     ENABLE_QUERY_LOGGING: z.boolean().optional().default(false),
+    LOG_RETENTION_DAYS: z.coerce
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .default(0),
+    LOG_RETENTION_CRON_SECRET: z.string().optional(),
     REDIS_HOST: z.string().optional().default("localhost"),
     REDIS_PORT: z.number().optional().default(6379),
     REDIS_PASSWORD: z.string().optional(),
@@ -68,6 +75,8 @@ export const env = createEnv({
     DATABASE_URL: process.env.DATABASE_URL,
     DEBUG: process.env.DEBUG === "true",
     ENABLE_QUERY_LOGGING: process.env.ENABLE_QUERY_LOGGING === "true",
+    LOG_RETENTION_DAYS: process.env.LOG_RETENTION_DAYS,
+    LOG_RETENTION_CRON_SECRET: process.env.LOG_RETENTION_CRON_SECRET,
     REDIS_HOST: process.env.REDIS_HOST,
     REDIS_PORT: process.env.REDIS_PORT
       ? parseInt(process.env.REDIS_PORT)

--- a/src/server/api/routers/log.ts
+++ b/src/server/api/routers/log.ts
@@ -1,5 +1,16 @@
-import { createTRPCRouter, protectedProcedure } from "@zapcron/server/api/trpc";
+import {
+  createTRPCRouter,
+  privilegedProcedure,
+  protectedProcedure,
+} from "@zapcron/server/api/trpc";
 import { logs } from "@zapcron/server/db/schema";
+import {
+  countExpiredLogs,
+  getLogRetentionCutoffDate,
+  getLogRetentionDays,
+  isLogRetentionEnabled,
+  purgeExpiredLogs,
+} from "@zapcron/server/logs/retention";
 import { zClearLog, zGetAllLogByJobInput } from "@zapcron/zod/log";
 import { and, eq, gte, lt, lte } from "drizzle-orm";
 
@@ -56,12 +67,26 @@ export const logRouter = createTRPCRouter({
     if (sizeResult.length > 0) {
       size = sizeResult[0]?.size as string;
     }
+    const retentionDays = getLogRetentionDays();
+    const cutoffDate = getLogRetentionCutoffDate();
+    const expiredCount = isLogRetentionEnabled()
+      ? await countExpiredLogs(ctx.db)
+      : 0;
+
     return {
       total,
       size,
       oldest: oldest?.createdAt.toISOString(),
       newest: newest?.createdAt.toISOString(),
+      retentionDays,
+      retentionEnabled: isLogRetentionEnabled(),
+      cutoffDate: cutoffDate?.toISOString() ?? null,
+      expiredCount,
     };
+  }),
+
+  purgeExpired: privilegedProcedure.mutation(async ({ ctx }) => {
+    return await purgeExpiredLogs(ctx.db);
   }),
 
   clear: protectedProcedure

--- a/src/server/logs/retention.ts
+++ b/src/server/logs/retention.ts
@@ -1,0 +1,57 @@
+import { env } from "@zapcron/env";
+import type { db } from "@zapcron/server/db";
+import { logs } from "@zapcron/server/db/schema";
+import { count, lt } from "drizzle-orm";
+
+export function getLogRetentionDays(): number {
+  return env.LOG_RETENTION_DAYS;
+}
+
+export function isLogRetentionEnabled(): boolean {
+  return getLogRetentionDays() > 0;
+}
+
+export function getLogRetentionCutoffDate(): Date | null {
+  const retentionDays = getLogRetentionDays();
+  if (retentionDays <= 0) {
+    return null;
+  }
+
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - retentionDays);
+  return cutoff;
+}
+
+export async function purgeExpiredLogs(database: typeof db) {
+  const retentionDays = getLogRetentionDays();
+  const cutoff = getLogRetentionCutoffDate();
+
+  if (!cutoff) {
+    return { deleted: 0, retentionDays };
+  }
+
+  const deleted = await database
+    .delete(logs)
+    .where(lt(logs.createdAt, cutoff))
+    .returning({ id: logs.id });
+
+  if (deleted.length > 0) {
+    await database.execute("VACUUM ANALYZE zc_log");
+  }
+
+  return { deleted: deleted.length, retentionDays };
+}
+
+export async function countExpiredLogs(database: typeof db) {
+  const cutoff = getLogRetentionCutoffDate();
+  if (!cutoff) {
+    return 0;
+  }
+
+  const [result] = await database
+    .select({ value: count() })
+    .from(logs)
+    .where(lt(logs.createdAt, cutoff));
+
+  return result?.value ?? 0;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds environment-based configuration for how long job execution logs are retained, with automated and manual purge paths.

## Changes

- **`LOG_RETENTION_DAYS`** — Number of days to keep logs (`0` = disabled, default). Logs older than the cutoff are eligible for purge.
- **`LOG_RETENTION_CRON_SECRET`** — Optional secret for the purge API (required to call the endpoint).
- **`POST /api/logs/purge`** — Secured endpoint for external schedulers (Kubernetes CronJob, system cron, etc.). Accepts `Authorization: Bearer <secret>` or `x-log-retention-secret`.
- **`log.purgeExpired`** — Admin-only tRPC mutation to purge expired logs on demand.
- **`log.getStats`** — Now includes retention policy, cutoff date, and expired log count.
- **Settings → Log Management** — Displays retention policy and a purge button when expired logs exist.

## Usage

```env
LOG_RETENTION_DAYS=30
LOG_RETENTION_CRON_SECRET=your-secret-here
```

Example cron (daily at 2am):

```bash
curl -X POST https://your-zapcron-host/api/logs/purge \
  -H "Authorization: Bearer your-secret-here"
```

## Notes

- Retention is opt-in (`LOG_RETENTION_DAYS=0` by default) so existing deployments are unchanged.
- Purge runs `VACUUM ANALYZE` on `zc_log` after deleting rows (same as manual clear).
- Manual **Clear Logs** behavior is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-700075d8-fff1-47c0-b713-e38896973753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-700075d8-fff1-47c0-b713-e38896973753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Introduce configurable job log retention with automated and manual purge capabilities.

New Features:
- Add environment-configurable log retention period via LOG_RETENTION_DAYS and optional purge secret via LOG_RETENTION_CRON_SECRET.
- Expose a POST /api/logs/purge endpoint secured by a shared secret header or bearer token for scheduled log purging.
- Add an admin-only tRPC mutation to purge expired logs and extend log stats with retention metadata (policy, cutoff date, expired count).
- Enhance the Settings → Log Management UI to display retention status and allow purging of expired logs when present.

Documentation:
- Document job log retention configuration, purge endpoint usage, and admin purge controls in the README.